### PR TITLE
feat: (#20) add Stylelint server auto-restart support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.0.10 (2026-03-01)
+* Add Stylelint server auto-restart support ([#20](https://github.com/neotan/vscode-auto-restart-typescript-eslint-servers/issues/20))
+  * Monitors `.stylelintrc`, `.stylelintrc.{js,mjs,cjs,yml,yaml,json}`, `stylelint.config.{js,mjs,cjs,ts}`, and `.git/HEAD`
+  * Configurable via `autoRestart.monitorFilesForStylelint`, `autoRestart.fileGlobForStylelint`, and `autoRestart.showRestartNotificationForStylelint`
+
 ### 0.0.9 (2026-01-22)
 * Add `**/.git/HEAD` glob pattern to default file monitoring for both TypeScript and ESLint ([#14](https://github.com/neotan/vscode-auto-restart-typescript-eslint-servers/issues/14))
 * Improve configuration descriptions with proper markdown formatting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vscode-auto-restart-typescript-eslint-servers
 
-Automatically restart TypeScript and ESLint servers when configuration files change—no manual restarts needed! 🚀
+Automatically restart TypeScript, ESLint, and Stylelint servers when configuration files change—no manual restarts needed! 🚀
 <img src="https://raw.githubusercontent.com/neotan/vscode-auto-restart-typescript-eslint-servers/master/images/_banner.png" alt="Banner" />
 
 ## VS Code Marketplace:
@@ -15,16 +15,17 @@ Works out of the box! The extension automatically monitors common configuration 
 ### ⚡ **Smart & Efficient**
 - **Intelligent Debouncing**: Batches rapid file changes (like during `npm install`) to prevent unnecessary server restarts, keeping your workspace responsive
 - **Selective Monitoring**: Automatically excludes `node_modules` and build directories to focus on what matters
-- **Performance Optimized**: Only watches files that actually affect your TypeScript/ESLint configuration
+- **Performance Optimized**: Only watches files that actually affect your TypeScript/ESLint/Stylelint configuration
 
 ### 🎯 **Comprehensive File Monitoring**
 Automatically detects changes to:
 - **TypeScript**: `tsconfig.json`, `tsconfig.app.json`, `tsconfig.app.js`, and more
 - **ESLint**: `.eslintrc.*` files (JS, CJS, MJS, YAML, JSON) and modern `eslint.config.*` files
+- **Stylelint**: `.stylelintrc`, `.stylelintrc.*` files (JS, MJS, CJS, YAML, JSON) and `stylelint.config.*` files
 - **Git Integration**: Monitors `.git/HEAD` to catch branch switches and configuration updates
 
 ### 🛠️ **Fully Customizable**
-- **Independent Controls**: Enable/disable TypeScript and ESLint monitoring separately
+- **Independent Controls**: Enable/disable TypeScript, ESLint, and Stylelint monitoring separately
 - **Custom Glob Patterns**: Configure exactly which files to monitor using VS Code's glob pattern syntax
 - **Flexible Exclusions**: Add your own exclude patterns to ignore specific directories
 - **Notification Preferences**: Choose whether to see restart notifications for each server type
@@ -36,7 +37,7 @@ Perfect for large projects using Turborepo, Lerna, Nx, or other monorepo tools. 
 ### 💡 **Developer Experience**
 - **Instant Feedback**: Get notified when servers restart (optional)
 - **No Manual Restarts**: Never manually restart servers again—the extension handles it automatically
-- **Works Seamlessly**: Integrates with VS Code's built-in TypeScript and ESLint extensions
+- **Works Seamlessly**: Integrates with VS Code's built-in TypeScript, ESLint, and Stylelint extensions
 
 ---
 
@@ -91,4 +92,5 @@ You can now test the functionality of the extension within VSCode.
 ## Credits
 * [vscode-restart-ts-server-button](https://github.com/qcz/vscode-restart-ts-server-button) by [Qcz](github.com/qcz)
 * [vscode-eslint](https://github.com/microsoft/vscode-eslint) by [Microsoft](github.com/microsoft)
+* [vscode-stylelint](https://github.com/stylelint/vscode-stylelint) by [Stylelint](github.com/stylelint)
  

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-auto-restart-typescript-eslint-servers",
-  "displayName": "Auto Restart TypeScript / ESLint Servers",
-  "description": "Restart TypeScript / ESLint servers AUTOMATICALLY when monitored files were changed.",
+  "displayName": "Auto Restart TypeScript / ESLint / Stylelint Servers",
+  "description": "Restart TypeScript / ESLint / Stylelint servers AUTOMATICALLY when monitored files were changed.",
   "publisher": "neotan",
   "version": "0.0.10",
   "engines": {
@@ -28,6 +28,11 @@
     "tsconfig",
     "eslint",
     "eslintrc",
+    "stylelint",
+    "stylelintrc",
+    "css",
+    "scss",
+    "less",
     "server",
     "turborepo",
     "lerna",
@@ -46,7 +51,7 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "Auto Restart TypeScript / ESLint Servers",
+      "title": "Auto Restart TypeScript / ESLint / Stylelint Servers",
       "properties": {
         "autoRestart.monitorFilesForTypescript": {
           "type": "boolean",
@@ -90,6 +95,29 @@
           "default": true,
           "scope": "window",
           "markdownDescription": "Show notification when restarts ESLint server."
+        },
+        "autoRestart.monitorFilesForStylelint": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Monitor Stylelint config files and restart its server."
+        },
+        "autoRestart.fileGlobForStylelint": {
+          "type": "array",
+          "default": [
+            "**/.stylelintrc",
+            "**/.stylelintrc.{js,mjs,cjs,yml,yaml,json}",
+            "**/stylelint.config.{js,mjs,cjs,ts}",
+            "**/.git/HEAD"
+          ],
+          "scope": "window",
+          "markdownDescription": "Monitors these files, supports [Glob Pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern). Default `[\"**/.stylelintrc\", \"**/.stylelintrc.{js,mjs,cjs,yml,yaml,json}\", \"**/stylelint.config.{js,mjs,cjs,ts}\", \"**/.git/HEAD\"]`."
+        },
+        "autoRestart.showRestartNotificationForStylelint": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Show notification when restarts Stylelint server."
         },
         "autoRestart.debounceDelayMs": {
           "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,22 +12,27 @@ import {
 type ConfigProperties = {
   monitorFilesForTypescript: boolean
   monitorFilesForESLint: boolean
+  monitorFilesForStylelint: boolean
   fileGlobForTypescript: GlobPattern | GlobPattern[]
   fileGlobForESLint: GlobPattern | GlobPattern[]
+  fileGlobForStylelint: GlobPattern | GlobPattern[]
   showRestartNotificationForTypescript: boolean
   showRestartNotificationForESLint: boolean
+  showRestartNotificationForStylelint: boolean
   debounceDelayMs: number
   excludePatterns: string[]
 }
 
 const TS_EXT_ID = 'vscode.typescript-language-features'
 const ESLINT_EXT_ID = 'dbaeumer.vscode-eslint'
+const STYLELINT_EXT_ID = 'stylelint.vscode-stylelint'
 const THIS_EXT_NAME = 'vscode-auto-restart-typescript-eslint-servers'
 const THIS_EXT_ID = `neotan.${THIS_EXT_NAME}`
 const THIS_EXT_CONFIG_PREFIX = `autoRestart` // i.e. Configuration `section`
 
 let tsWatcher: Disposable
 let eslintWatcher: Disposable
+let stylelintWatcher: Disposable
 
 export function activate(context: ExtensionContext) {
   workspace.onDidChangeConfiguration((e) => {
@@ -38,6 +43,7 @@ export function activate(context: ExtensionContext) {
     if (e.affectsConfiguration(THIS_EXT_CONFIG_PREFIX)) {
       tsWatcher?.dispose()
       eslintWatcher?.dispose()
+      stylelintWatcher?.dispose()
 
       if (getConfig('monitorFilesForTypescript')) {
         tsWatcher = initWatcher('Typescript', restartTsServer)
@@ -45,6 +51,10 @@ export function activate(context: ExtensionContext) {
 
       if (getConfig('monitorFilesForESLint')) {
         eslintWatcher = initWatcher('ESLint', restartEslintServer)
+      }
+
+      if (getConfig('monitorFilesForStylelint')) {
+        stylelintWatcher = initWatcher('Stylelint', restartStylelintServer)
       }
     }
   })
@@ -56,11 +66,16 @@ export function activate(context: ExtensionContext) {
   if (getConfig('monitorFilesForESLint')) {
     eslintWatcher = initWatcher('ESLint', restartEslintServer)
   }
+
+  if (getConfig('monitorFilesForStylelint')) {
+    stylelintWatcher = initWatcher('Stylelint', restartStylelintServer)
+  }
 }
 
 export function deactivate() {
   tsWatcher?.dispose()
   eslintWatcher?.dispose()
+  stylelintWatcher?.dispose()
   console.log(`Extension ${THIS_EXT_ID} is now deactivated!`)
 }
 
@@ -119,8 +134,18 @@ function restartEslintServer() {
   return commands.executeCommand("eslint.restart")
 }
 
+function restartStylelintServer() {
+  const stylelintExtension = extensions.getExtension(STYLELINT_EXT_ID)
+  if (!stylelintExtension || stylelintExtension.isActive === false) {
+    window.showErrorMessage("Stylelint extension is not active or not running.")
+    return
+  }
+
+  return commands.executeCommand("stylelint.restart")
+}
+
 function initWatcher(
-  serverType: 'Typescript' | 'ESLint',
+  serverType: 'Typescript' | 'ESLint' | 'Stylelint',
   cb: () => Thenable<unknown> | void
 ): Disposable {
   let globs = getConfig(`fileGlobFor${serverType}`)


### PR DESCRIPTION
## Summary
  - Add Stylelint server auto-restart support, matching the existing TypeScript/ESLint pattern
  - Monitor `.stylelintrc`, `.stylelintrc.{js,mjs,cjs,yml,yaml,json}`,
  `stylelint.config.{js,mjs,cjs,ts}`, and `.git/HEAD` by default
  - Add 3 new configuration properties: `monitorFilesForStylelint`, `fileGlobForStylelint`,
  `showRestartNotificationForStylelint`
  - Update metadata (displayName, description, keywords) and documentation (README, CHANGELOG)

  Closes #20

  ## Test plan
  - [x] `npm run compile` passes with no errors
  - [x] Modify a `.stylelintrc.json` → Stylelint server restarts with notification
  - [x] Set `monitorFilesForStylelint: false` → no restart on config change
  - [x] With `vscode-stylelint` uninstalled → error message shown gracefully
  - [x] New settings appear correctly in VS Code settings UI