### PR TITLE
feat: add Remark and Astro server auto-restart support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+* Add remark language server auto-restart support
+  * Monitors `.remarkignore`, `.remarkrc*`, `package.json`, and `.git/HEAD`
+  * Configurable via `autoRestart.monitorFilesForRemark`, `autoRestart.fileGlobForRemark`, and `autoRestart.showRestartNotificationForRemark`
+* Add Astro language server auto-restart support
+  * Monitors `astro.config.{mjs,js,ts,mts}` and `.git/HEAD`
+  * Configurable via `autoRestart.monitorFilesForAstro`, `autoRestart.fileGlobForAstro`, and `autoRestart.showRestartNotificationForAstro`
+
 ### 0.0.11 (2026-03-01)
 * Add Stylelint server auto-restart support ([#20](https://github.com/neotan/vscode-auto-restart-typescript-eslint-servers/issues/20))
   * Monitors `.stylelintrc`, `.stylelintrc.{js,mjs,cjs,yml,yaml,json}`, `stylelint.config.{js,mjs,cjs,ts}`, and `.git/HEAD`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vscode-auto-restart-typescript-eslint-servers
 
-Automatically restart TypeScript, ESLint, and Stylelint servers when configuration files change—no manual restarts needed! 🚀
+Automatically restart TypeScript, ESLint, Stylelint, remark, and Astro servers when configuration files change—no manual restarts needed! 🚀
 <img src="https://raw.githubusercontent.com/neotan/vscode-auto-restart-typescript-eslint-servers/master/images/_banner.png" alt="Banner" />
 
 ## VS Code Marketplace:
@@ -15,17 +15,19 @@ Works out of the box! The extension automatically monitors common configuration 
 ### ⚡ **Smart & Efficient**
 - **Intelligent Debouncing**: Batches rapid file changes (like during `npm install`) to prevent unnecessary server restarts, keeping your workspace responsive
 - **Selective Monitoring**: Automatically excludes `node_modules` and build directories to focus on what matters
-- **Performance Optimized**: Only watches files that actually affect your TypeScript/ESLint/Stylelint configuration
+- **Performance Optimized**: Only watches files that actually affect your supported language-server configuration
 
 ### 🎯 **Comprehensive File Monitoring**
 Automatically detects changes to:
 - **TypeScript**: `tsconfig.json`, `tsconfig.app.json`, `tsconfig.app.js`, and more
 - **ESLint**: `.eslintrc.*` files (JS, CJS, MJS, YAML, JSON) and modern `eslint.config.*` files
 - **Stylelint**: `.stylelintrc`, `.stylelintrc.*` files (JS, MJS, CJS, YAML, JSON) and `stylelint.config.*` files
+- **remark**: `.remarkignore`, `.remarkrc*`, and `package.json`
+- **Astro**: `astro.config.mjs`, `astro.config.js`, `astro.config.ts`, and `astro.config.mts`
 - **Git Integration**: Monitors `.git/HEAD` to catch branch switches and configuration updates
 
 ### 🛠️ **Fully Customizable**
-- **Independent Controls**: Enable/disable TypeScript, ESLint, and Stylelint monitoring separately
+- **Independent Controls**: Enable/disable monitoring for each supported server separately
 - **Custom Glob Patterns**: Configure exactly which files to monitor using VS Code's glob pattern syntax
 - **Flexible Exclusions**: Add your own exclude patterns to ignore specific directories
 - **Notification Preferences**: Choose whether to see restart notifications for each server type
@@ -37,7 +39,7 @@ Perfect for large projects using Turborepo, Lerna, Nx, or other monorepo tools. 
 ### 💡 **Developer Experience**
 - **Instant Feedback**: Get notified when servers restart (optional)
 - **No Manual Restarts**: Never manually restart servers again—the extension handles it automatically
-- **Works Seamlessly**: Integrates with VS Code's built-in TypeScript, ESLint, and Stylelint extensions
+- **Works Seamlessly**: Integrates with VS Code's built-in TypeScript support and the ESLint, Stylelint, remark, and Astro extensions
 
 ---
 
@@ -93,4 +95,6 @@ You can now test the functionality of the extension within VSCode.
 * [vscode-restart-ts-server-button](https://github.com/qcz/vscode-restart-ts-server-button) by [Qcz](github.com/qcz)
 * [vscode-eslint](https://github.com/microsoft/vscode-eslint) by [Microsoft](github.com/microsoft)
 * [vscode-stylelint](https://github.com/stylelint/vscode-stylelint) by [Stylelint](github.com/stylelint)
+* [vscode-remark](https://github.com/remarkjs/vscode-remark) by [remark](https://github.com/remarkjs)
+* [Astro language tools](https://github.com/withastro/language-tools) by [Astro](https://github.com/withastro)
  

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-auto-restart-typescript-eslint-servers",
-  "displayName": "Auto Restart TypeScript / ESLint / Stylelint Servers",
-  "description": "Restart TypeScript / ESLint / Stylelint servers AUTOMATICALLY when monitored files were changed.",
+  "displayName": "Auto Restart TypeScript / ESLint / Stylelint / Remark / Astro Servers",
+  "description": "Restart TypeScript, ESLint, Stylelint, Remark, and Astro servers AUTOMATICALLY when monitored files were changed.",
   "publisher": "neotan",
   "version": "0.0.11",
   "engines": {
@@ -30,6 +30,10 @@
     "eslintrc",
     "stylelint",
     "stylelintrc",
+    "remark",
+    "remarkrc",
+    "markdown",
+    "astro",
     "css",
     "scss",
     "less",
@@ -51,7 +55,7 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "Auto Restart TypeScript / ESLint / Stylelint Servers",
+      "title": "Auto Restart TypeScript / ESLint / Stylelint / Remark / Astro Servers",
       "properties": {
         "autoRestart.monitorFilesForTypescript": {
           "type": "boolean",
@@ -118,6 +122,49 @@
           "default": true,
           "scope": "window",
           "markdownDescription": "Show notification when restarts Stylelint server."
+        },
+        "autoRestart.monitorFilesForRemark": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Monitor remark config and ignore files and restart its language server."
+        },
+        "autoRestart.fileGlobForRemark": {
+          "type": "array",
+          "default": [
+            "**/.remark{ignore,rc,rc.cjs,rc.js,rc.json,rc.mjs,rc.yaml,rc.yml}",
+            "**/package.json",
+            "**/.git/HEAD"
+          ],
+          "scope": "window",
+          "markdownDescription": "Monitors these files, supports [Glob Pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern). Default `[\"**/.remark{ignore,rc,rc.cjs,rc.js,rc.json,rc.mjs,rc.yaml,rc.yml}\", \"**/package.json\", \"**/.git/HEAD\"]`."
+        },
+        "autoRestart.showRestartNotificationForRemark": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Show notification when restarts remark language server."
+        },
+        "autoRestart.monitorFilesForAstro": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Monitor Astro config files and restart its language server."
+        },
+        "autoRestart.fileGlobForAstro": {
+          "type": "array",
+          "default": [
+            "**/astro.config.{mjs,js,ts,mts}",
+            "**/.git/HEAD"
+          ],
+          "scope": "window",
+          "markdownDescription": "Monitors these files, supports [Glob Pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern). Default `[\"**/astro.config.{mjs,js,ts,mts}\", \"**/.git/HEAD\"]`."
+        },
+        "autoRestart.showRestartNotificationForAstro": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Show notification when restarts Astro language server."
         },
         "autoRestart.debounceDelayMs": {
           "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import {
   commands,
   Disposable,
+  Extension,
   ExtensionContext,
   extensions,
   GlobPattern,
@@ -13,19 +14,37 @@ type ConfigProperties = {
   monitorFilesForTypescript: boolean
   monitorFilesForESLint: boolean
   monitorFilesForStylelint: boolean
+  monitorFilesForRemark: boolean
+  monitorFilesForAstro: boolean
   fileGlobForTypescript: GlobPattern | GlobPattern[]
   fileGlobForESLint: GlobPattern | GlobPattern[]
   fileGlobForStylelint: GlobPattern | GlobPattern[]
+  fileGlobForRemark: GlobPattern | GlobPattern[]
+  fileGlobForAstro: GlobPattern | GlobPattern[]
   showRestartNotificationForTypescript: boolean
   showRestartNotificationForESLint: boolean
   showRestartNotificationForStylelint: boolean
+  showRestartNotificationForRemark: boolean
+  showRestartNotificationForAstro: boolean
   debounceDelayMs: number
   excludePatterns: string[]
+}
+
+type AstroLanguageClient = {
+  restart: () => Thenable<void>
+}
+
+type AstroExtensionExports = {
+  volarLabs?: {
+    languageClients?: AstroLanguageClient[]
+  }
 }
 
 const TS_EXT_ID = 'vscode.typescript-language-features'
 const ESLINT_EXT_ID = 'dbaeumer.vscode-eslint'
 const STYLELINT_EXT_ID = 'stylelint.vscode-stylelint'
+const REMARK_EXT_ID = 'unifiedjs.vscode-remark'
+const ASTRO_EXT_ID = 'astro-build.astro-vscode'
 const THIS_EXT_NAME = 'vscode-auto-restart-typescript-eslint-servers'
 const THIS_EXT_ID = `neotan.${THIS_EXT_NAME}`
 const THIS_EXT_CONFIG_PREFIX = `autoRestart` // i.e. Configuration `section`
@@ -33,6 +52,8 @@ const THIS_EXT_CONFIG_PREFIX = `autoRestart` // i.e. Configuration `section`
 let tsWatcher: Disposable
 let eslintWatcher: Disposable
 let stylelintWatcher: Disposable
+let remarkWatcher: Disposable
+let astroWatcher: Disposable
 
 export function activate(context: ExtensionContext) {
   workspace.onDidChangeConfiguration((e) => {
@@ -44,6 +65,8 @@ export function activate(context: ExtensionContext) {
       tsWatcher?.dispose()
       eslintWatcher?.dispose()
       stylelintWatcher?.dispose()
+      remarkWatcher?.dispose()
+      astroWatcher?.dispose()
 
       if (getConfig('monitorFilesForTypescript')) {
         tsWatcher = initWatcher('Typescript', restartTsServer)
@@ -55,6 +78,14 @@ export function activate(context: ExtensionContext) {
 
       if (getConfig('monitorFilesForStylelint')) {
         stylelintWatcher = initWatcher('Stylelint', restartStylelintServer)
+      }
+
+      if (getConfig('monitorFilesForRemark')) {
+        remarkWatcher = initWatcher('Remark', restartRemarkServer)
+      }
+
+      if (getConfig('monitorFilesForAstro')) {
+        astroWatcher = initWatcher('Astro', restartAstroServer)
       }
     }
   })
@@ -70,12 +101,22 @@ export function activate(context: ExtensionContext) {
   if (getConfig('monitorFilesForStylelint')) {
     stylelintWatcher = initWatcher('Stylelint', restartStylelintServer)
   }
+
+  if (getConfig('monitorFilesForRemark')) {
+    remarkWatcher = initWatcher('Remark', restartRemarkServer)
+  }
+
+  if (getConfig('monitorFilesForAstro')) {
+    astroWatcher = initWatcher('Astro', restartAstroServer)
+  }
 }
 
 export function deactivate() {
   tsWatcher?.dispose()
   eslintWatcher?.dispose()
   stylelintWatcher?.dispose()
+  remarkWatcher?.dispose()
+  astroWatcher?.dispose()
   console.log(`Extension ${THIS_EXT_ID} is now deactivated!`)
 }
 
@@ -114,39 +155,81 @@ function isExcluded(filePath: string): boolean {
   })
 }
 
-function restartTsServer() {
-  const tsExtension = extensions.getExtension(TS_EXT_ID)
-  if (!tsExtension || tsExtension.isActive === false) {
-    window.showErrorMessage(`${THIS_EXT_NAME} is not active or not running.`)
-    return
+function getActiveExtension<T>(
+  extensionId: string,
+  extensionName: string
+): Extension<T> | undefined {
+  const extension = extensions.getExtension<T>(extensionId)
+  if (!extension || extension.isActive === false) {
+    window.showErrorMessage(
+      `${extensionName} extension is not active or not running.`
+    )
+    return undefined
   }
 
-  return commands.executeCommand("typescript.restartTsServer")
+  return extension
 }
 
-function restartEslintServer() {
-  const eslintExtension = extensions.getExtension(ESLINT_EXT_ID)
-  if (!eslintExtension || eslintExtension.isActive === false) {
-    window.showErrorMessage("ESLint extension is not active or not running.")
-    return
+async function restartTsServer(): Promise<boolean> {
+  if (!getActiveExtension(TS_EXT_ID, 'TypeScript')) {
+    return false
   }
 
-  return commands.executeCommand("eslint.restart")
+  await commands.executeCommand('typescript.restartTsServer')
+  return true
 }
 
-function restartStylelintServer() {
-  const stylelintExtension = extensions.getExtension(STYLELINT_EXT_ID)
-  if (!stylelintExtension || stylelintExtension.isActive === false) {
-    window.showErrorMessage("Stylelint extension is not active or not running.")
-    return
+async function restartEslintServer(): Promise<boolean> {
+  if (!getActiveExtension(ESLINT_EXT_ID, 'ESLint')) {
+    return false
   }
 
-  return commands.executeCommand("stylelint.restart")
+  await commands.executeCommand('eslint.restart')
+  return true
+}
+
+async function restartStylelintServer(): Promise<boolean> {
+  if (!getActiveExtension(STYLELINT_EXT_ID, 'Stylelint')) {
+    return false
+  }
+
+  await commands.executeCommand('stylelint.restart')
+  return true
+}
+
+async function restartRemarkServer(): Promise<boolean> {
+  if (!getActiveExtension(REMARK_EXT_ID, 'Remark')) {
+    return false
+  }
+
+  await commands.executeCommand('remark.restart')
+  return true
+}
+
+async function restartAstroServer(): Promise<boolean> {
+  const astroExtension = getActiveExtension<AstroExtensionExports>(
+    ASTRO_EXT_ID,
+    'Astro'
+  )
+  if (!astroExtension) {
+    return false
+  }
+
+  const languageClients = astroExtension.exports.volarLabs?.languageClients
+  if (!languageClients?.length) {
+    window.showErrorMessage(
+      'Astro extension does not expose an active language server.'
+    )
+    return false
+  }
+
+  await Promise.all(languageClients.map(client => client.restart()))
+  return true
 }
 
 function initWatcher(
-  serverType: 'Typescript' | 'ESLint' | 'Stylelint',
-  cb: () => Thenable<unknown> | void
+  serverType: 'Typescript' | 'ESLint' | 'Stylelint' | 'Remark' | 'Astro',
+  cb: () => Thenable<boolean>
 ): Disposable {
   let globs = getConfig(`fileGlobFor${serverType}`)
   // Compatibility with older configuration format
@@ -157,7 +240,10 @@ function initWatcher(
   // Debounced handler shared across all globs and event types for this server
   const debouncedRestart = debounce(async (filePath: string, type: string) => {
     try {
-      await cb()
+      const restarted = await cb()
+      if (!restarted) {
+        return
+      }
       if (getConfig(`showRestartNotificationFor${serverType}`)) {
         window.showInformationMessage(
           `${serverType} Server Restarted as file(s) ${type}: ${filePath}`

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,34 @@
-import * as assert from 'assert';
+import * as assert from 'assert'
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import * as vscode from 'vscode'
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+  vscode.window.showInformationMessage('Start all tests.')
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
-});
+  test('activates with Remark and Astro watcher defaults', async () => {
+    const extension = vscode.extensions.getExtension(
+      'neotan.vscode-auto-restart-typescript-eslint-servers'
+    )
+    assert.ok(extension)
+
+    await extension.activate()
+
+    const config = vscode.workspace.getConfiguration('autoRestart')
+    assert.strictEqual(config.get('monitorFilesForRemark'), true)
+    assert.deepStrictEqual(config.get('fileGlobForRemark'), [
+      '**/.remark{ignore,rc,rc.cjs,rc.js,rc.json,rc.mjs,rc.yaml,rc.yml}',
+      '**/package.json',
+      '**/.git/HEAD',
+    ])
+    assert.strictEqual(config.get('showRestartNotificationForRemark'), true)
+
+    assert.strictEqual(config.get('monitorFilesForAstro'), true)
+    assert.deepStrictEqual(config.get('fileGlobForAstro'), [
+      '**/astro.config.{mjs,js,ts,mts}',
+      '**/.git/HEAD',
+    ])
+    assert.strictEqual(config.get('showRestartNotificationForAstro'), true)
+  })
+})


### PR DESCRIPTION
## Summary

- add independently configurable file watchers for the remark and Astro language servers
- restart remark through its official `remark.restart` command
- restart Astro's exported Volar language clients directly because the Astro extension does not contribute a server-restart command
- avoid success notifications when a target extension or language client is unavailable
- document the new defaults and replace the placeholder extension test with coverage for the new settings

## Why

Remark and Astro projects can retain stale language-server state after configuration changes or branch switches. This extends the existing automatic restart behavior to both servers while preserving the extension's per-server controls, custom globs, debounce, exclusions, and notification settings.

## User impact

The new watchers are enabled by default and can be controlled with:

- `autoRestart.monitorFilesForRemark`, `autoRestart.fileGlobForRemark`, and `autoRestart.showRestartNotificationForRemark`
- `autoRestart.monitorFilesForAstro`, `autoRestart.fileGlobForAstro`, and `autoRestart.showRestartNotificationForAstro`

## Validation

- `npm run compile`
- `npm run lint` (0 errors; 63 existing warnings remain in the untouched test runner files)
- extension-host tests on VS Code 1.129.1 (`1 passing`)
- `npm run package`
- `git diff --check`
